### PR TITLE
readme: remove internals

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,11 +9,11 @@ linters:
     - lll
     - nlreturn
     - wsl
-    - scopelint
-    - golint
-    - gomoddirectives
-    - interfacer
-    - maligned
+    - scopelint # deprecated
+    - golint # deprecated
+    - gomoddirectives # deprecated
+    - interfacer # deprecated
+    - maligned # deprecated
 
 issues:
   exclude-rules:

--- a/README.md
+++ b/README.md
@@ -2,27 +2,31 @@
 
 Provide basic operations on calendars in Go.
 
-## Installation
-
-### Clone
-
-`calendar` is a private project of [`edgelaboratories`](https://github.com/edgelaboratories) and must be installed by setting the `GONOPROXY` and `GONOSUMDB` variables first:
+## Install
 
 ```bash
-GONOPROXY=github.com/edgelaboratories/calendar GONOSUMDB=github.com/edgelaboratories/calendar go get github.com/edgelaboratories/calendar
+go get -u github.com/edgelaboratories/calendar
 ```
 
-### Requirements
+## Requirements
 
-[go 1.17.x](https://golang.org/dl/)
+- [go 1.17.x](https://golang.org/dl/)
+
+## Test
+
+Run the following:
+
+```bash
+make test
+```
+
+Check out the [`Makefile`](Makefile) for more information.
 
 ## Purpose
 
-This project **aims** at offering a unique, simple and fast module to manage calendars based on `date.Date`.
+This project aims at offering a unique, simple and fast module to manage calendars with daily granularity. Dates representation is based on [`github.com/fxtlabs/date`](https://github.com/fxtlabs/date).
 
-The natural extension to intra-day durations implies the usage of `time.Time` and `time.Duration`, which is nowadays not needed.
-
-This project **doesn't aim at** supporting daycount conventions; have a look at [`edgelaboratories/daycount`](https://github.com/edgelaboratories/daycount) instead.
+This project **doesn't aim** at supporting daycount conventions. Have a look at [`github.com/edgelaboratories/daycount`](https://github.com/edgelaboratories/daycount) instead.
 
 ## Usage
 
@@ -32,6 +36,7 @@ package main
 import (
     "fmt"
     "github.com/edgelaboratories/calendar"
+    "github.com/fxtlabs/date"
 )
 
 func main() {


### PR DESCRIPTION
- Follows https://github.com/edgelaboratories/calendar/discussions/3#discussioncomment-1471727
- Removing all mentions to internal issues/choices
- Commenting deprecated linters explicitly

@vthiery @greut same as for `daycount`: feel free to publish this module once this PR is merged, there shouldn't be other blocking points (at least on my side).