### PR TITLE
fix: do not embed daycounter

### DIFF
--- a/business_calendar.go
+++ b/business_calendar.go
@@ -15,20 +15,20 @@ func newBusinessCalendar() *businessCalendar {
 }
 
 // isActive returns true if the input date is active.
-func (c businessCalendar) IsActive(date date.Date) bool {
+func (c businessCalendar) isActive(date date.Date) bool {
 	return c.isBusinessDay(date)
 }
 
-// yearDuration returns the standard year duration according to the
+// daysInYear returns the standard year duration according to the
 // business-days calendar.
-func (c businessCalendar) DaysInYear() int {
+func (c businessCalendar) daysInYear() int {
 	return 252
 }
 
-// Add adds an input number of active days to the input origin date.
+// add adds an input number of active days to the input origin date.
 // The days parameter is allowed to be negative.
 // This method is idempotent when a zero-days shift is requested.
-func (c businessCalendar) Add(origin date.Date, days int) date.Date {
+func (c businessCalendar) add(origin date.Date, days int) date.Date {
 	if days == 0 {
 		// In order for the method to be idempotent, the same result must
 		// be obtained by shifting forwards and backwards (or viceversa)
@@ -66,14 +66,14 @@ func (c businessCalendar) Add(origin date.Date, days int) date.Date {
 	return current.Add((days / 5) * 7)
 }
 
-// DaysBetween computes the number of active dates between
+// daysBetween computes the number of active dates between
 // from (excluded) and to (included).
 // This implies there are zero business days from a Friday to
 // a weekend day, but there is one between a weekend day and
 // a Monday.
-func (c businessCalendar) DaysBetween(from, to date.Date) int {
+func (c businessCalendar) daysBetween(from, to date.Date) int {
 	if from.After(to) {
-		return -c.DaysBetween(to, from)
+		return -c.daysBetween(to, from)
 	}
 
 	// Shift both dates to the closest Sunday and then add

--- a/business_calendar_test.go
+++ b/business_calendar_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_businessCalendar_IsActive(t *testing.T) {
+func Test_businessCalendar_isActive(t *testing.T) {
 	calendar := newBusinessCalendar()
 
 	for _, tc := range []struct {
@@ -32,15 +32,15 @@ func Test_businessCalendar_IsActive(t *testing.T) {
 			true,
 		},
 	} {
-		assert.Equal(t, tc.expected, calendar.IsActive(tc.date))
+		assert.Equal(t, tc.expected, calendar.isActive(tc.date))
 	}
 }
 
-func Test_businessCalendar_DaysInYear(t *testing.T) {
-	assert.Equal(t, 252, newBusinessCalendar().DaysInYear())
+func Test_businessCalendar_daysInYear(t *testing.T) {
+	assert.Equal(t, 252, newBusinessCalendar().daysInYear())
 }
 
-func Test_businessCalendar_Add(t *testing.T) {
+func Test_businessCalendar_add(t *testing.T) {
 	calendar := newBusinessCalendar()
 
 	for _, tc := range []struct {
@@ -89,11 +89,11 @@ func Test_businessCalendar_Add(t *testing.T) {
 			date.New(2020, time.September, 7),
 		},
 	} {
-		assert.Equal(t, tc.expected, calendar.Add(tc.origin, tc.days))
+		assert.Equal(t, tc.expected, calendar.add(tc.origin, tc.days))
 	}
 }
 
-func Test_businessCalendar_DaysBetween(t *testing.T) {
+func Test_businessCalendar_daysBetween(t *testing.T) {
 	calendar := newBusinessCalendar()
 
 	for _, tc := range []struct {
@@ -137,8 +137,8 @@ func Test_businessCalendar_DaysBetween(t *testing.T) {
 			20,
 		},
 	} {
-		assert.Equal(t, tc.expected, calendar.DaysBetween(tc.from, tc.to))
-		assert.Equal(t, -tc.expected, calendar.DaysBetween(tc.to, tc.from))
+		assert.Equal(t, tc.expected, calendar.daysBetween(tc.from, tc.to))
+		assert.Equal(t, -tc.expected, calendar.daysBetween(tc.to, tc.from))
 	}
 }
 
@@ -161,17 +161,17 @@ func Test_businessCalendar_DaysBetween_AcrossWeekend(t *testing.T) {
 		// Get the days across the weekend and check they're consistent.
 		saturday := friday.Add(1)
 		sunday := friday.Add(2)
-		monday := calendar.Add(friday, 1)
+		monday := calendar.add(friday, 1)
 		assert.Equal(t, friday.Add(3), monday)
 
 		// There's no business days from a business day to a non-business day.
-		assert.Equal(t, 0, calendar.DaysBetween(friday, saturday))
-		assert.Equal(t, 0, calendar.DaysBetween(friday, sunday))
-		assert.Equal(t, 1, calendar.DaysBetween(friday, monday))
+		assert.Equal(t, 0, calendar.daysBetween(friday, saturday))
+		assert.Equal(t, 0, calendar.daysBetween(friday, sunday))
+		assert.Equal(t, 1, calendar.daysBetween(friday, monday))
 
 		// There is one business day from a non-business day to a business day.
-		assert.Equal(t, 1, calendar.DaysBetween(saturday, monday))
-		assert.Equal(t, 1, calendar.DaysBetween(sunday, monday))
+		assert.Equal(t, 1, calendar.daysBetween(saturday, monday))
+		assert.Equal(t, 1, calendar.daysBetween(sunday, monday))
 	}
 }
 
@@ -247,19 +247,19 @@ func Test_businessCalendar_ConsistencyChecks(t *testing.T) {
 			current := origin.Add(j)
 
 			for i := 1; i <= 256; i++ {
-				to := calendar.Add(current, i)
-				from := calendar.Add(to, -i)
+				to := calendar.add(current, i)
+				from := calendar.add(to, -i)
 
 				// Forward-shifted date by i days should not equal the current date.
 				assert.False(t, current.Equal(to))
 
 				// Ensure between current/from and to there are exactly i business days.
-				assert.Equal(t, i, calendar.DaysBetween(current, to))
-				assert.Equal(t, i, calendar.DaysBetween(from, to))
+				assert.Equal(t, i, calendar.daysBetween(current, to))
+				assert.Equal(t, i, calendar.daysBetween(from, to))
 
 				// Ensure forward and backward shifts are consistent.
-				assert.True(t, calendar.Add(from, i).Equal(to))
-				assert.True(t, calendar.Add(to, -i).Equal(from))
+				assert.True(t, calendar.add(from, i).Equal(to))
+				assert.True(t, calendar.add(to, -i).Equal(from))
 			}
 		}
 	})
@@ -273,10 +273,10 @@ func Test_businessCalendar_ConsistencyChecks(t *testing.T) {
 			calendar = newBusinessCalendar()
 		)
 
-		assert.True(t, calendar.Add(thursday, 0).Equal(thursday))
-		assert.True(t, calendar.Add(friday, 0).Equal(friday))
-		assert.True(t, calendar.Add(saturday, 0).Equal(friday))
-		assert.True(t, calendar.Add(sunday, 0).Equal(friday))
+		assert.True(t, calendar.add(thursday, 0).Equal(thursday))
+		assert.True(t, calendar.add(friday, 0).Equal(friday))
+		assert.True(t, calendar.add(saturday, 0).Equal(friday))
+		assert.True(t, calendar.add(sunday, 0).Equal(friday))
 	})
 
 	t.Run("shift across weekend", func(t *testing.T) {
@@ -288,23 +288,23 @@ func Test_businessCalendar_ConsistencyChecks(t *testing.T) {
 			calendar            = newBusinessCalendar()
 		)
 
-		assert.Equal(t, calendar.DaysBetween(from, to), businessDaysBetween)
-		assert.True(t, calendar.Add(to, -businessDaysBetween).Equal(from))
+		assert.Equal(t, calendar.daysBetween(from, to), businessDaysBetween)
+		assert.True(t, calendar.add(to, -businessDaysBetween).Equal(from))
 		assert.True(t, calendar.previousBusinessDay(to).Equal(businessBeforeTo))
-		assert.True(t, calendar.Add(from, businessDaysBetween).Equal(businessBeforeTo))
+		assert.True(t, calendar.add(from, businessDaysBetween).Equal(businessBeforeTo))
 	})
 
 	t.Run("all shifts", func(t *testing.T) {
 		origin := date.New(2017, time.January, 9)
 		for i := 1; i <= 256; i++ {
-			to := calendar.Add(origin, i)
-			from := calendar.Add(to, -i)
+			to := calendar.add(origin, i)
+			from := calendar.add(to, -i)
 
 			assert.False(t, origin.Equal(to))
-			assert.Equal(t, i, calendar.DaysBetween(origin, to))
-			assert.Equal(t, i, calendar.DaysBetween(from, to))
-			assert.True(t, calendar.Add(from, i).Equal(to))
-			assert.True(t, calendar.Add(to, -i).Equal(from))
+			assert.Equal(t, i, calendar.daysBetween(origin, to))
+			assert.Equal(t, i, calendar.daysBetween(from, to))
+			assert.True(t, calendar.add(from, i).Equal(to))
+			assert.True(t, calendar.add(to, -i).Equal(from))
 		}
 	})
 
@@ -330,10 +330,10 @@ func Test_businessCalendar_ConsistencyChecks(t *testing.T) {
 			assert.True(t, !calendar.isBusinessDay(current) || (from.Equal(current) && to.Equal(current)))
 			// When current is not a business day, it is assumed equal to the latest
 			// business day before it, so it always coincides with from.
-			assert.Equal(t, 0, calendar.DaysBetween(from, current))
+			assert.Equal(t, 0, calendar.daysBetween(from, current))
 			// Daily difference between from/current and to is equivalent.
-			assert.Equal(t, dayDiff, calendar.DaysBetween(current, to))
-			assert.Equal(t, dayDiff, calendar.DaysBetween(from, to))
+			assert.Equal(t, dayDiff, calendar.daysBetween(current, to))
+			assert.Equal(t, dayDiff, calendar.daysBetween(from, to))
 		}
 	})
 }

--- a/calendar.go
+++ b/calendar.go
@@ -4,17 +4,39 @@ import "github.com/fxtlabs/date"
 
 // Calendar exposes functions to manipulate dates with respect to a calendar.
 type Calendar struct {
-	dayCounter
-
+	dayCounter dayCounter
 	convention Convention
 }
 
 // New returns a calendar based on the specified input convention.
 func New(convention Convention) *Calendar {
 	return &Calendar{
-		newDayCounter(convention),
-		convention,
+		dayCounter: newDayCounter(convention),
+		convention: convention,
 	}
+}
+
+// IsActive returns true if the input date is active.
+func (c *Calendar) IsActive(date date.Date) bool {
+	return c.dayCounter.isActive(date)
+}
+
+// add adds an input number of active days to the input origin date.
+// The days parameter is allowed to be negative.
+// This method is idempotent for zero-days shifts.
+func (c *Calendar) Add(origin date.Date, days int) date.Date {
+	return c.dayCounter.add(origin, days)
+}
+
+// DaysBetween computes the number of active dates between
+// from (excluded) and to (included).
+func (c *Calendar) DaysBetween(from, to date.Date) int {
+	return c.dayCounter.daysBetween(from, to)
+}
+
+// DaysInYear returns the calendar's standard year duration (in days).
+func (c *Calendar) DaysInYear() int {
+	return c.dayCounter.daysInYear()
 }
 
 // LatestBefore returns the latest date before or equal to

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -65,6 +65,54 @@ func Test_Calendar_DaysInYear(t *testing.T) {
 	assert.Equal(t, 365, New(CalendarDays).DaysInYear())
 }
 
+func Test_Calendar_Add(t *testing.T) {
+	for _, tc := range []struct {
+		convention Convention
+		origin     date.Date
+		days       int
+		expected   date.Date
+	}{
+		{
+			CalendarDays,
+			date.New(2021, time.October, 18),
+			7,
+			date.New(2021, time.October, 25),
+		},
+		{
+			BusinessDays,
+			date.New(2021, time.October, 18),
+			5,
+			date.New(2021, time.October, 25),
+		},
+	} {
+		assert.Equal(t, tc.expected, New(tc.convention).Add(tc.origin, tc.days))
+	}
+}
+
+func Test_Calendar_DaysBetween(t *testing.T) {
+	for _, tc := range []struct {
+		convention Convention
+		from       date.Date
+		to         date.Date
+		expected   int
+	}{
+		{
+			CalendarDays,
+			date.New(2021, time.October, 18),
+			date.New(2021, time.October, 25),
+			7,
+		},
+		{
+			BusinessDays,
+			date.New(2021, time.October, 18),
+			date.New(2021, time.October, 25),
+			5,
+		},
+	} {
+		assert.Equal(t, tc.expected, New(tc.convention).DaysBetween(tc.from, tc.to))
+	}
+}
+
 func Benchmark_Calendar_Add(b *testing.B) {
 	var (
 		origin = date.New(2021, time.January, 1)

--- a/day_counter.go
+++ b/day_counter.go
@@ -10,10 +10,10 @@ import "github.com/fxtlabs/date"
 // The methods of the daycounter are implementation-dependent
 // and allow to exploit the calendar properties.
 type dayCounter interface {
-	IsActive(date date.Date) bool
-	DaysInYear() int
-	DaysBetween(from, to date.Date) int
-	Add(origin date.Date, days int) date.Date
+	isActive(date date.Date) bool
+	daysInYear() int
+	daysBetween(from, to date.Date) int
+	add(origin date.Date, days int) date.Date
 }
 
 func newDayCounter(convention Convention) dayCounter {

--- a/physical_calendar.go
+++ b/physical_calendar.go
@@ -13,25 +13,25 @@ func newPhysicalCalendar() *physicalCalendar {
 // isActive returns whether the input date is active according
 // to the physical calendar. By definition the result is true
 // for every input date.
-func (c physicalCalendar) IsActive(date date.Date) bool {
+func (c physicalCalendar) isActive(date date.Date) bool {
 	return true
 }
 
-// yearDuration returns the standard year duration according to the
+// daysInYear returns the standard year duration according to the
 // physical-days calendar.
-func (c physicalCalendar) DaysInYear() int {
+func (c physicalCalendar) daysInYear() int {
 	return 365
 }
 
-// Add adds an input number of active days to the input origin date.
+// add adds an input number of active days to the input origin date.
 // The days parameter is allowed to be negative.
-func (c physicalCalendar) Add(origin date.Date, days int) date.Date {
+func (c physicalCalendar) add(origin date.Date, days int) date.Date {
 	return origin.Add(days)
 }
 
-// DaysBetween computes the number of active dates between
+// daysBetween computes the number of active dates between
 // from (excluded) and to (included).
 // The from parameter is supposed not to be after to.
-func (c physicalCalendar) DaysBetween(from, to date.Date) int {
+func (c physicalCalendar) daysBetween(from, to date.Date) int {
 	return to.Sub(from)
 }

--- a/physical_calendar_test.go
+++ b/physical_calendar_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_physicalCalendar_IsActive(t *testing.T) {
+func Test_physicalCalendar_isActive(t *testing.T) {
 	calendar := newPhysicalCalendar()
 
 	for _, tc := range []struct {
@@ -33,15 +33,15 @@ func Test_physicalCalendar_IsActive(t *testing.T) {
 			true,
 		},
 	} {
-		assert.Equal(t, tc.expected, calendar.IsActive(tc.date))
+		assert.Equal(t, tc.expected, calendar.isActive(tc.date))
 	}
 }
 
-func Test_physicalCalendar_DaysInYear(t *testing.T) {
-	assert.Equal(t, 365, newPhysicalCalendar().DaysInYear())
+func Test_physicalCalendar_daysInYear(t *testing.T) {
+	assert.Equal(t, 365, newPhysicalCalendar().daysInYear())
 }
 
-func Test_physicalCalendar_Add(t *testing.T) {
+func Test_physicalCalendar_add(t *testing.T) {
 	calendar := newPhysicalCalendar()
 
 	for _, tc := range []struct {
@@ -67,12 +67,12 @@ func Test_physicalCalendar_Add(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(fmt.Sprintf("from %s plus %d", tc.origin, tc.days), func(t *testing.T) {
-			assert.Equal(t, tc.expected, calendar.Add(tc.origin, tc.days))
+			assert.Equal(t, tc.expected, calendar.add(tc.origin, tc.days))
 		})
 	}
 }
 
-func Test_physicalCalendar_DaysBetween(t *testing.T) {
+func Test_physicalCalendar_daysBetween(t *testing.T) {
 	calendar := newPhysicalCalendar()
 
 	for _, tc := range []struct {
@@ -96,6 +96,6 @@ func Test_physicalCalendar_DaysBetween(t *testing.T) {
 			29,
 		},
 	} {
-		assert.Equal(t, tc.expected, calendar.DaysBetween(tc.from, tc.to))
+		assert.Equal(t, tc.expected, calendar.daysBetween(tc.from, tc.to))
 	}
 }


### PR DESCRIPTION
## What

The [package Go reference](https://pkg.go.dev/github.com/edgelaboratories/calendar) doesn't expose the methods of the embedded (unexported) `dayCounter`.

## Why is it like that?

A former implementation relied on
```go
type dayCounter struct {
   IsActive(date date.Date) bool
   YearDuration() float64
}
```
as the minimal inner daycounter interface, and defined `Add`, `DaysBetween` etc. directly based on the usage of `IsActive`:
- this generic implementation grants the minimal daycounter interface while defining all calendar methods on top on it
- however, the price to pay for this generality is bad performance (_O(n)_ instead of _O(1)_)

Now that the daycounter takes full responsibility for the methods implementation, the embedding:
```go
type Calendar struct {
   dayCounter
}
```

is not necessary anymore and merely obfuscates useful methods that should be publicly documented.

## Fix

- Unexport daycounter methods
- Add public methods on calendar based on the inner daycounter
- Include tests where missing
