### PR TITLE
build(fmt): update fmt target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ COVERAGE_OUT ?= bin/cover.out
 .PHONY: fmt
 fmt:
 	go mod tidy -go=1.17
-	gofumpt -s -w .
-	gofumports -w .
+	gofumpt -w .
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
- Use [`v0.3.1`](https://github.com/mvdan/gofumpt/releases/tag/v0.3.1) by `go install mvdan.cc/gofumpt@latest`
- Remove `-s` option (as enabled by default)
- `make fmt`
- Drop `gofumports`:

> gofumports is now removed, after being deprecated in v0.1.0. Its main purpose was IDE integration; it is now recommended to use gopls, which in turn implements goimports and supports gofumpt natively