### PR TITLE
Improve performance of businessCalendar's add()

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - lll
     - nlreturn
     - wsl
+    - varnamelen
     - scopelint # deprecated
     - golint # deprecated
     - gomoddirectives # deprecated

--- a/business_calendar.go
+++ b/business_calendar.go
@@ -69,6 +69,7 @@ func (c businessCalendar) daysBetween(from, to date.Date) int {
 		start = start.Add(2)
 	case time.Saturday:
 		start = start.Add(1)
+	case time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Sunday:
 	}
 
 	// Shift end date to previous Friday if on Saturday or Sunday.
@@ -77,6 +78,7 @@ func (c businessCalendar) daysBetween(from, to date.Date) int {
 		end = end.Add(-1)
 	case time.Sunday:
 		end = end.Add(-2)
+	case time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday:
 	}
 
 	// Compute raw day difference.

--- a/business_calendar.go
+++ b/business_calendar.go
@@ -42,15 +42,11 @@ func (c businessCalendar) add(origin date.Date, days int) date.Date {
 	// Number of business days left after shifting by nbWeeks
 	nbDaysLeft := days - (nbWeeks * 5)
 
+	// If the nbDaysLeft does not fit in the current week, then add two days for the weekend.
+	nbDaysLeft = addWeekendDays(current, nbDaysLeft, days)
+
 	// Total number of days (this number will eventually be incremented below)
 	nbDays := nbWeeks*7 + nbDaysLeft
-
-	// If the nbDaysLeft does not fit in the current week, then add two days for the weekend
-	if days > 0 && int(time.Friday-current.Weekday()) < nbDaysLeft {
-		nbDays += 2
-	} else if days < 0 && int(current.Weekday()-time.Monday) < -nbDaysLeft {
-		nbDays -= 2
-	}
 
 	return current.Add(nbDays)
 }
@@ -126,4 +122,15 @@ func (c businessCalendar) closestBusinessDay(origin date.Date, forwards bool) da
 			return current
 		}
 	}
+}
+
+// addWeekendDays adds or removes 2 days to the day count (nbDaysLeft) to skip the weekend days.
+func addWeekendDays(current date.Date, nbDaysLeft, days int) int {
+	if days > 0 && int(time.Friday-current.Weekday()) < nbDaysLeft {
+		return nbDaysLeft + 2
+	} else if days < 0 && int(current.Weekday()-time.Monday) < -nbDaysLeft {
+		return nbDaysLeft - 2
+	}
+
+	return nbDaysLeft
 }

--- a/business_calendar.go
+++ b/business_calendar.go
@@ -128,7 +128,9 @@ func (c businessCalendar) closestBusinessDay(origin date.Date, forwards bool) da
 func addWeekendDays(current date.Date, nbDaysLeft, days int) int {
 	if days > 0 && int(time.Friday-current.Weekday()) < nbDaysLeft {
 		return nbDaysLeft + 2
-	} else if days < 0 && int(current.Weekday()-time.Monday) < -nbDaysLeft {
+	}
+
+	if days < 0 && int(current.Weekday()-time.Monday) < -nbDaysLeft {
 		return nbDaysLeft - 2
 	}
 

--- a/business_calendar.go
+++ b/business_calendar.go
@@ -67,18 +67,30 @@ func (c businessCalendar) daysBetween(from, to date.Date) int {
 	switch start.Weekday() {
 	case time.Friday:
 		start = start.Add(2)
+
 	case time.Saturday:
 		start = start.Add(1)
-	case time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Sunday:
+
+	case time.Monday,
+		time.Tuesday,
+		time.Wednesday,
+		time.Thursday,
+		time.Sunday:
 	}
 
 	// Shift end date to previous Friday if on Saturday or Sunday.
 	switch end.Weekday() {
 	case time.Saturday:
 		end = end.Add(-1)
+
 	case time.Sunday:
 		end = end.Add(-2)
-	case time.Monday, time.Tuesday, time.Wednesday, time.Thursday, time.Friday:
+
+	case time.Monday,
+		time.Tuesday,
+		time.Wednesday,
+		time.Thursday,
+		time.Friday:
 	}
 
 	// Compute raw day difference.

--- a/business_calendar_test.go
+++ b/business_calendar_test.go
@@ -342,7 +342,7 @@ func BenchmarkShiftBusinessDays(b *testing.B) {
 	calendar := newBusinessCalendar()
 	startingDate := date.New(2017, time.November, 9)
 
-	for _, bc := range []struct {
+	for _, benchmarkCase := range []struct {
 		name  string
 		shift int
 	}{
@@ -363,7 +363,7 @@ func BenchmarkShiftBusinessDays(b *testing.B) {
 			17,
 		},
 	} {
-		bc := bc
+		bc := benchmarkCase
 		b.Run(bc.name, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				_ = calendar.add(startingDate, bc.shift)

--- a/business_calendar_test.go
+++ b/business_calendar_test.go
@@ -342,7 +342,7 @@ func BenchmarkShiftBusinessDays(b *testing.B) {
 	calendar := newBusinessCalendar()
 	startingDate := date.New(2017, time.November, 9)
 
-	for _, benchmarkCase := range []struct {
+	for _, bc := range []struct {
 		name  string
 		shift int
 	}{
@@ -363,7 +363,7 @@ func BenchmarkShiftBusinessDays(b *testing.B) {
 			17,
 		},
 	} {
-		bc := benchmarkCase
+		bc := bc
 		b.Run(bc.name, func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				_ = calendar.add(startingDate, bc.shift)

--- a/business_calendar_test.go
+++ b/business_calendar_test.go
@@ -338,34 +338,36 @@ func Test_businessCalendar_ConsistencyChecks(t *testing.T) {
 	})
 }
 
-func benchmarkShiftBusinessDays(b *testing.B, shift int, date date.Date) {
-	b.Helper()
+func BenchmarkShiftBusinessDays(b *testing.B) {
 	calendar := newBusinessCalendar()
-	for n := 0; n < b.N; n++ {
-		_ = calendar.add(date, shift)
+	startingDate := date.New(2017, time.November, 9)
+
+	for _, bc := range []struct {
+		name  string
+		shift int
+	}{
+		{
+			"add 17 days",
+			17,
+		},
+		{
+			"remove 17 days",
+			-17,
+		},
+		{
+			"add 7778 days",
+			17,
+		},
+		{
+			"remove 7778 days",
+			17,
+		},
+	} {
+		bc := bc
+		b.Run(bc.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_ = calendar.add(startingDate, bc.shift)
+			}
+		})
 	}
-}
-
-func BenchmarkShiftBusinessDays_17(b *testing.B) {
-	date := date.New(2017, time.November, 9)
-	shift := 17
-	benchmarkShiftBusinessDays(b, shift, date)
-}
-
-func BenchmarkShiftminusBusinessDays_m17(b *testing.B) {
-	date := date.New(2017, time.November, 9)
-	shift := -17
-	benchmarkShiftBusinessDays(b, shift, date)
-}
-
-func BenchmarkShiftBusinessDays_7778(b *testing.B) {
-	date := date.New(2017, time.November, 9)
-	shift := 7778
-	benchmarkShiftBusinessDays(b, shift, date)
-}
-
-func BenchmarkShiftBusinessDays_m7778(b *testing.B) {
-	date := date.New(2017, time.November, 9)
-	shift := -7778
-	benchmarkShiftBusinessDays(b, shift, date)
 }

--- a/business_calendar_test.go
+++ b/business_calendar_test.go
@@ -337,3 +337,35 @@ func Test_businessCalendar_ConsistencyChecks(t *testing.T) {
 		}
 	})
 }
+
+func benchmarkShiftBusinessDays(b *testing.B, shift int, date date.Date) {
+	b.Helper()
+	calendar := newBusinessCalendar()
+	for n := 0; n < b.N; n++ {
+		_ = calendar.add(date, shift)
+	}
+}
+
+func BenchmarkShiftBusinessDays_17(b *testing.B) {
+	date := date.New(2017, time.November, 9)
+	shift := 17
+	benchmarkShiftBusinessDays(b, shift, date)
+}
+
+func BenchmarkShiftminusBusinessDays_m17(b *testing.B) {
+	date := date.New(2017, time.November, 9)
+	shift := -17
+	benchmarkShiftBusinessDays(b, shift, date)
+}
+
+func BenchmarkShiftBusinessDays_7778(b *testing.B) {
+	date := date.New(2017, time.November, 9)
+	shift := 7778
+	benchmarkShiftBusinessDays(b, shift, date)
+}
+
+func BenchmarkShiftBusinessDays_m7778(b *testing.B) {
+	date := date.New(2017, time.November, 9)
+	shift := -7778
+	benchmarkShiftBusinessDays(b, shift, date)
+}


### PR DESCRIPTION
# Context

Similar to [edgelaboratories/tarantino#674](https://github.com/edgelaboratories/tarantino/pull/674)

This PR improves the performance of the function `add`.

# Content

Modification to `add` to avoid looping and calling itself. 

Benchmark added

# How we know it works

Tests pass. No new test added

# Benchmark results

### Intro

I considered four shift values `17`, `-17`, `7778` and `-7778`, referred to in the function names as `xxx_17`, `xxx_m17`, `xxx_7778`, `xxx_m7778`. The large values are irealistic and are used only for considerations of extremes.

### Results

version in master

```
BenchmarkShiftBusinessDays_17-8         	87126721	        11.93 ns/op	       0 B/op	       0 allocs/op
BenchmarkShiftminusBusinessDays_m17-8   	127907304	        9.362 ns/op	       0 B/op	       0 allocs/op
BenchmarkShiftBusinessDays_7778-8       	99965977	        11.94 ns/op	       0 B/op	       0 allocs/op
BenchmarkShiftBusinessDays_m7778-8      	100000000	        11.71 ns/op	       0 B/op	       0 allocs/op
```

version in this branch

```
BenchmarkShiftBusinessDays_17-8         	196057020	         6.129 ns/op	       0 B/op	       0 allocs/op
BenchmarkShiftminusBusinessDays_m17-8   	196296846	         6.138 ns/op	       0 B/op	       0 allocs/op
BenchmarkShiftBusinessDays_7778-8       	197015299	         6.086 ns/op	       0 B/op	       0 allocs/op
BenchmarkShiftBusinessDays_m7778-8      	195863832	         6.120 ns/op	       0 B/op	       0 allocs/op
```

### Discussion

The new version is slightly slower than tarantino's. I would assume this is because tarantino avoid using a date.Date. Also, the old version of calendar was not as bad as tarantino's old version. As a consequence, the improvement is not as extreme as observed in [edgelaboratories/tarantino#674](https://github.com/edgelaboratories/tarantino/pull/674).