### PR TITLE
fix: renovate config cannot use private preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "labels": [
     "dependencies"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,49 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>edgelaboratories/renovate-config:quant-engine"
+  "dependencyDashboard": true,
+  "labels": [
+    "dependencies"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": [
+      "security"
+    ]
+  },
+  "schedule": [
+    "before 5am on Wednesday"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest",
+        "bump"
+      ],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all"
+    },
+    {
+      "matchDatasources": [
+        "go",
+        "golang-version"
+      ],
+      "groupName": "go packages",
+      "groupSlug": "go-packages"
+    },
+    {
+      "matchPackageNames": [
+        "go"
+      ],
+      "groupName": "go version",
+      "groupSlug": "go"
+    }
   ]
 }


### PR DESCRIPTION
- Closes #28 
- See https://github.com/renovatebot/renovate/discussions/9002

Aggregating the available private presets into a single one to start off with. We may use a public preset later on, if needed.