### PR TITLE
chore(lint): update golangci-lint to 1.52.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - structcheck
     - nosnakecase
     - ifshort
+    - musttag
     # Disabled because of generics
     - rowserrcheck
     - sqlclosecheck

--- a/physical_calendar.go
+++ b/physical_calendar.go
@@ -13,7 +13,7 @@ func newPhysicalCalendar() *physicalCalendar {
 // isActive returns whether the input date is active according
 // to the physical calendar. By definition the result is true
 // for every input date.
-func (c physicalCalendar) isActive(date date.Date) bool {
+func (c physicalCalendar) isActive(date.Date) bool {
 	return true
 }
 


### PR DESCRIPTION
# Context #

PRs are blocked due to update of golangci-lint 1.52.1 release.

# Content #

This PR pleases `revive`.
I removed `musttag` temporary as in [Hippo #347](https://github.com/edgelaboratories/hippo/pull/347) due to the following error :
```
can't run linter goanalysis_metalinter: musttag: running `go list all`: exit status 1
```

