### PR TITLE
dep: set golangci-lint version to v1.53.2.

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.5.0
         with:
-          version: latest
+          version: v1.53.2


### PR DESCRIPTION
Why this PR?
=======
The renovate config is now able to update the golangci-lint version used in the repo. This PR aims at setting a static version for golangci-lint instead of using the `latest` version

How does it work?
========
The version of golangci-lint is set at v1.53.2.
