### PR TITLE
code: upgrade to Go 1.21

### DIFF
--- a/.github/workflows/golangci.yml
+++ b/.github/workflows/golangci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - name: Update dependencies
         run: go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ go get -u github.com/edgelaboratories/calendar
 
 ## Requirements
 
-- [go 1.20.x](https://golang.org/dl/)
+- [go 1.21.x](https://golang.org/dl/)
 
 ## Test
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelaboratories/calendar
 
-go 1.20
+go 1.21
 
 require (
 	github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9


### PR DESCRIPTION
# Context (why?) #

Update to Go 1.21, on the similar model to https://github.com/edgelaboratories/eve/pull/1627

# Content (what?) #

Change occurences of Go 1.20 to 1.21 and `go mod tidy`.