### PR TITLE
dep: use edgelaboratories/date instead of fxtlabs/date

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check out the [`Makefile`](Makefile) for more information.
 
 ## Purpose
 
-This project aims at offering a unique, simple and fast module to manage calendars with daily granularity. Dates representation is based on [`github.com/fxtlabs/date`](https://github.com/fxtlabs/date).
+This project aims at offering a unique, simple and fast module to manage calendars with daily granularity. Dates representation is based on [`github.com/edgelaboratories/date`](https://github.com/edgelaboratories/date).
 
 This project **doesn't aim** at supporting daycount conventions. Have a look at [`github.com/edgelaboratories/daycount`](https://github.com/edgelaboratories/daycount) instead.
 
@@ -39,7 +39,7 @@ package main
 import (
     "fmt"
     "github.com/edgelaboratories/calendar"
-    "github.com/fxtlabs/date"
+    "github.com/edgelaboratories/date"
 )
 
 func main() {

--- a/business_calendar.go
+++ b/business_calendar.go
@@ -3,7 +3,7 @@ package calendar
 import (
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 )
 
 // businessCalendar is a calendar whose active days are working ones.

--- a/business_calendar_test.go
+++ b/business_calendar_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/calendar.go
+++ b/calendar.go
@@ -1,6 +1,6 @@
 package calendar
 
-import "github.com/fxtlabs/date"
+import "github.com/edgelaboratories/date"
 
 // dayCounter defines the properties of a calendar.
 type dayCounter interface {

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/edgelaboratories/calendar
 go 1.21
 
 require (
-	github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9
+	github.com/edgelaboratories/date v1.0.0
 	github.com/stretchr/testify v1.8.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9 h1:NERIc41aohgojUAgWCCnN5B8dIXZsBo2UC04LR3tbao=
-github.com/fxtlabs/date v0.0.0-20150819233934-d9ab6e2a88a9/go.mod h1:UoIEyXCyEJ1Zu3ejiUOSngl9U5Oe9S+qaNiYiUex2nk=
+github.com/edgelaboratories/date v1.0.0 h1:7fLFULv4CN8p4y2tF4HL6pkiineu9pTB7tPY5JGmMU8=
+github.com/edgelaboratories/date v1.0.0/go.mod h1:Tp8irw0RW41T/Bnhe8q6AZjDyVuDcwPU3vl93t2GoOM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/physical_calendar.go
+++ b/physical_calendar.go
@@ -1,6 +1,6 @@
 package calendar
 
-import "github.com/fxtlabs/date"
+import "github.com/edgelaboratories/date"
 
 // physicalCalendar defines a calendar in which all days
 // (including weekends) are active.

--- a/physical_calendar_test.go
+++ b/physical_calendar_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fxtlabs/date"
+	"github.com/edgelaboratories/date"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
## Context

Follows the work started by https://github.com/edgelaboratories/daycount/pull/61

## Content

This PR replaces the use of `fxtlabs/date` by `edgelaboratories/date` 